### PR TITLE
prefer track performer over album artist

### DIFF
--- a/Plugin.pm
+++ b/Plugin.pm
@@ -988,7 +988,7 @@ sub _playlistItem {
 sub _trackItem {
 	my ($client, $track, $isWeb) = @_;
 
-	my $artist = $track->{album}->{artist}->{name} || $track->{performer}->{name} || '';
+	my $artist = $track->{performer}->{name} || $track->{album}->{artist}->{name} || '';
 	my $album  = $track->{album}->{title} || '';
 
 	my $item = {


### PR DESCRIPTION
Prefer the main performer of the track as artist instead of the album's artist to handle various artists albums.

As it is now, when listing playlists with tracks in it from various artists (compilation) albums, the artist is listed as "Various Artists" which is kind of annoying as the track itself actually has a performer.

This simple adjustment fixes that where the performer of the track is used instead of the album's artist.