### PR TITLE
Classical music enhancements

### DIFF
--- a/API/Common.pm
+++ b/API/Common.pm
@@ -32,9 +32,19 @@ my $cache;
 my $prefs = preferences('plugin.qobuz');
 my $log = logger('plugin.qobuz');
 my $isClassique;
+my %genreList;
+
+initGenreMap();
+
+$prefs->setChange(\&initGenreMap, 'classicalGenres');
+
 sub init {
 	my $class = shift;
 	return pack('H*', $_[0]) =~ /^(\d{9})(.*)/
+}
+
+sub initGenreMap {
+   %genreList = map { $_ => 1 } split /\s*,\s*/, $prefs->get('classicalGenres');
 }
 
 sub getCache {
@@ -110,9 +120,8 @@ sub _precacheAlbum {
 		# If the user pref is for classical music enhancements to the display, is this a classical release or has the user added the genre to their custom classical list?
 		$isClassique = 0;
 		if ( $prefs->get('useClassicalEnhancements') ) {
-			my %genreList = map { $_ => 1 } split '\s*,\s*', $prefs->get('classicalGenres');	
 			if ( $album->{genres_list} && grep(/Classique/,@{$album->{genres_list}}) || $genreList{$album->{genre}} ) {
-			$isClassique = 1;
+				$isClassique = 1;
 			}
 		}
 

--- a/API/Common.pm
+++ b/API/Common.pm
@@ -95,7 +95,7 @@ sub _precacheAlbum {
 	$albums = __PACKAGE__->filterPlayables($albums);
 
 	foreach my $album (@$albums) {
-		foreach (qw(composer duration genres_list articles article_ids catchline
+		foreach (qw(composer duration articles article_ids catchline
 			# maximum_bit_depth maximum_channel_count maximum_sampling_rate maximum_technical_specifications
 			popularity previewable qobuz_id sampleable slug streamable_at subtitle created_at
 			product_type product_url purchasable purchasable_at relative_url release_date_download release_date_stream release_date_original
@@ -114,6 +114,8 @@ sub _precacheAlbum {
 			image  => $album->{image},
 			year   => (localtime($album->{released_at}))[5] + 1900,
 			goodies=> $album->{goodies},
+			genre  => $album->{genre},
+			genres_list => $album->{genres_list},
 		};
 
 		_precacheTracks([ map {
@@ -169,6 +171,8 @@ sub precacheTrack {
 		goodies  => $album->{goodies},
 		version  => $track->{version},
 		work     => $track->{work},
+		genre    => $album->{genre},
+		genres_list => $album->{genres_list},
 	};
 
 	if ($track->{audio_info} && defined $track->{audio_info}->{replaygain_track_gain}) {

--- a/API/Common.pm
+++ b/API/Common.pm
@@ -120,7 +120,7 @@ sub _precacheAlbum {
 		# If the user pref is for classical music enhancements to the display, is this a classical release or has the user added the genre to their custom classical list?
 		$isClassique = 0;
 		if ( $prefs->get('useClassicalEnhancements') ) {
-			if ( $album->{genres_list} && grep(/Classique/,@{$album->{genres_list}}) || $genreList{$album->{genre}} ) {
+			if ( ( $album->{genres_list} && grep(/Classique/,@{$album->{genres_list}}) ) || $genreList{$album->{genre}} ) {
 				$isClassique = 1;
 			}
 		}

--- a/HTML/EN/plugins/Qobuz/settings/basic.html
+++ b/HTML/EN/plugins/Qobuz/settings/basic.html
@@ -46,15 +46,12 @@
 				<option [% prefs.useClassicalEnhancements ? "selected" : "" %] value="1" >[% "YES" | string %]</option>
 				<option [% prefs.useClassicalEnhancements ? "" : "selected" %] value="0" >[% "NO" | string %]</option>
 			</select>
-			<!--[% "PLUGIN_QOBUZ_USE_CLASSICAL_ENHANCEMENTS_DESC" | string %]
-			[% "PLUGIN_QOBUZ_CLASSICAL_GENRES" | string %]&nbsp;
-			<input type="text" class="stdedit" name="pref_classicalGenres" id="classicalGenres" value="[% prefs.classicalGenres %]" size="80">-->
 		[% END %]
 		[% WRAPPER settingGroup title="PLUGIN_QOBUZ_WORK_PLAYLIST_POSITION" desc="" %]
 			<select name="pref_workPlaylistPosition" id="workPlaylistPosition">
-			  <option [% prefs.workPlaylistPosition == "before" ? "selected" : "" %] value="before" >[% "PLUGIN_QOBUZ_WORK_PLAYLIST_POSITION_BEFORE" | string %]</option>
-			  <option [% prefs.workPlaylistPosition == "after"  ? "selected" : "" %] value="after" >[% "PLUGIN_QOBUZ_WORK_PLAYLIST_POSITION_AFTER" | string %]</option>
-		          <option [% prefs.workPlaylistPosition == "hidden" ? "selected" : "" %] value="hidden" >[% "PLUGIN_QOBUZ_WORK_PLAYLIST_POSITION_HIDDEN" | string %]</option>
+				<option [% prefs.workPlaylistPosition == "before" ? "selected" : "" %] value="before" >[% "PLUGIN_QOBUZ_WORK_PLAYLIST_POSITION_BEFORE" | string %]</option>
+				<option [% prefs.workPlaylistPosition == "after"  ? "selected" : "" %] value="after" >[% "PLUGIN_QOBUZ_WORK_PLAYLIST_POSITION_AFTER" | string %]</option>
+				<option [% prefs.workPlaylistPosition == "hidden" ? "selected" : "" %] value="hidden" >[% "PLUGIN_QOBUZ_WORK_PLAYLIST_POSITION_HIDDEN" | string %]</option>
 			</select>
 		[% END %]
 		[% WRAPPER settingGroup title="PLUGIN_QOBUZ_CLASSICAL_GENRES" desc="PLUGIN_QOBUZ_CLASSICAL_GENRES_DESC" %]

--- a/HTML/EN/plugins/Qobuz/settings/basic.html
+++ b/HTML/EN/plugins/Qobuz/settings/basic.html
@@ -40,7 +40,7 @@
 				<option [% prefs.showYearWithAlbum ? "" : "selected" %] value="0" >[% "NO" | string %]</option>
 			</select>
 		[% END %]
-		<hr style="opacity:0.4" class="sub-sep"/>
+		<hr class="sub-sep"/>
 		[% WRAPPER settingGroup title="PLUGIN_QOBUZ_USE_CLASSICAL_ENHANCEMENTS" desc="PLUGIN_QOBUZ_USE_CLASSICAL_ENHANCEMENTS_DESC" %]
 			<select name="pref_useClassicalEnhancements" id="useClassicalEnhancements">
 				<option [% prefs.useClassicalEnhancements ? "selected" : "" %] value="1" >[% "YES" | string %]</option>
@@ -58,7 +58,7 @@
 			<input type="text" class="stdedit" name="pref_classicalGenres" id="classicalGenres" value="[% prefs.classicalGenres %]" size="80">
 		[% "PLUGIN_QOBUZ_USE_CLASSICAL_ENHANCEMENTS_TEXT" | string %]
 		[% END %]
-		<hr style="opacity:0.4" class="sub-sep"/>
+		<hr class="sub-sep"/>
 
 		[% WRAPPER settingGroup title="PLUGIN_QOBUZ_IMPORT" desc="" %]
 			<input type="checkbox" [% IF prefs.pref_dontImportPurchases %]checked [% END %] class="stdedit" name="pref_dontImportPurchases" id="pref_dontImportPurchases" value="1" />

--- a/HTML/EN/plugins/Qobuz/settings/basic.html
+++ b/HTML/EN/plugins/Qobuz/settings/basic.html
@@ -41,6 +41,15 @@
 			</select>
 		[% END %]
 
+		[% WRAPPER settingGroup title="PLUGIN_QOBUZ_USE_CLASSICAL_ENHANCEMENTS" desc="PLUGIN_QOBUZ_USE_CLASSICAL_ENHANCEMENTS_DESC" %]
+			<select name="pref_useClassicalEnhancements" id="useClassicalEnhancements">
+				<option [% prefs.useClassicalEnhancements ? "selected" : "" %] value="1" >[% "YES" | string %]</option>
+				<option [% prefs.useClassicalEnhancements ? "" : "selected" %] value="0" >[% "NO" | string %]</option>
+			</select>
+			&nbsp;[% "PLUGIN_QOBUZ_CLASSICAL_GENRES" | string %]&nbsp;
+			<input type="text" class="stdedit" name="pref_classicalGenres" id="classicalGenres" value="[% prefs.classicalGenres %]" size="80">
+		[% END %]
+
 		[% WRAPPER settingGroup title="PLUGIN_QOBUZ_IMPORT" desc="" %]
 			<input type="checkbox" [% IF prefs.pref_dontImportPurchases %]checked [% END %] class="stdedit" name="pref_dontImportPurchases" id="pref_dontImportPurchases" value="1" />
 			<label for="pref_dontImportPurchases" class="stdlabel">[% "PLUGIN_QOBUZ_DONT_IMPORT_PURCHASES" | string %]</label>

--- a/HTML/EN/plugins/Qobuz/settings/basic.html
+++ b/HTML/EN/plugins/Qobuz/settings/basic.html
@@ -50,6 +50,13 @@
 			[% "PLUGIN_QOBUZ_CLASSICAL_GENRES" | string %]&nbsp;
 			<input type="text" class="stdedit" name="pref_classicalGenres" id="classicalGenres" value="[% prefs.classicalGenres %]" size="80">-->
 		[% END %]
+		[% WRAPPER settingGroup title="PLUGIN_QOBUZ_WORK_PLAYLIST_POSITION" desc="" %]
+			<select name="pref_workPlaylistPosition" id="workPlaylistPosition">
+			  <option [% prefs.workPlaylistPosition == "before" ? "selected" : "" %] value="before" >[% "PLUGIN_QOBUZ_WORK_PLAYLIST_POSITION_BEFORE" | string %]</option>
+			  <option [% prefs.workPlaylistPosition == "after"  ? "selected" : "" %] value="after" >[% "PLUGIN_QOBUZ_WORK_PLAYLIST_POSITION_AFTER" | string %]</option>
+		          <option [% prefs.workPlaylistPosition == "hidden" ? "selected" : "" %] value="hidden" >[% "PLUGIN_QOBUZ_WORK_PLAYLIST_POSITION_HIDDEN" | string %]</option>
+			</select>
+		[% END %]
 		[% WRAPPER settingGroup title="PLUGIN_QOBUZ_CLASSICAL_GENRES" desc="PLUGIN_QOBUZ_CLASSICAL_GENRES_DESC" %]
 			<input type="text" class="stdedit" name="pref_classicalGenres" id="classicalGenres" value="[% prefs.classicalGenres %]" size="80">
 		[% "PLUGIN_QOBUZ_USE_CLASSICAL_ENHANCEMENTS_TEXT" | string %]

--- a/HTML/EN/plugins/Qobuz/settings/basic.html
+++ b/HTML/EN/plugins/Qobuz/settings/basic.html
@@ -40,15 +40,21 @@
 				<option [% prefs.showYearWithAlbum ? "" : "selected" %] value="0" >[% "NO" | string %]</option>
 			</select>
 		[% END %]
-
+		<hr style="opacity:0.4" class="sub-sep"/>
 		[% WRAPPER settingGroup title="PLUGIN_QOBUZ_USE_CLASSICAL_ENHANCEMENTS" desc="PLUGIN_QOBUZ_USE_CLASSICAL_ENHANCEMENTS_DESC" %]
 			<select name="pref_useClassicalEnhancements" id="useClassicalEnhancements">
 				<option [% prefs.useClassicalEnhancements ? "selected" : "" %] value="1" >[% "YES" | string %]</option>
 				<option [% prefs.useClassicalEnhancements ? "" : "selected" %] value="0" >[% "NO" | string %]</option>
 			</select>
-			&nbsp;[% "PLUGIN_QOBUZ_CLASSICAL_GENRES" | string %]&nbsp;
-			<input type="text" class="stdedit" name="pref_classicalGenres" id="classicalGenres" value="[% prefs.classicalGenres %]" size="80">
+			<!--[% "PLUGIN_QOBUZ_USE_CLASSICAL_ENHANCEMENTS_DESC" | string %]
+			[% "PLUGIN_QOBUZ_CLASSICAL_GENRES" | string %]&nbsp;
+			<input type="text" class="stdedit" name="pref_classicalGenres" id="classicalGenres" value="[% prefs.classicalGenres %]" size="80">-->
 		[% END %]
+		[% WRAPPER settingGroup title="PLUGIN_QOBUZ_CLASSICAL_GENRES" desc="PLUGIN_QOBUZ_CLASSICAL_GENRES_DESC" %]
+			<input type="text" class="stdedit" name="pref_classicalGenres" id="classicalGenres" value="[% prefs.classicalGenres %]" size="80">
+		[% "PLUGIN_QOBUZ_USE_CLASSICAL_ENHANCEMENTS_TEXT" | string %]
+		[% END %]
+		<hr style="opacity:0.4" class="sub-sep"/>
 
 		[% WRAPPER settingGroup title="PLUGIN_QOBUZ_IMPORT" desc="" %]
 			<input type="checkbox" [% IF prefs.pref_dontImportPurchases %]checked [% END %] class="stdedit" name="pref_dontImportPurchases" id="pref_dontImportPurchases" value="1" />

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -1258,14 +1258,14 @@ sub _trackItem {
 					$item->{work} = $titleSplit[1];
 				}
 			}
-			$item->{line1} =~ s/$item->{work}://;
+			$item->{line1} =~ s/\Q$item->{work}\E://;
 		}
 		$item->{displayWork} = $item->{work};
 		$item->{displayWork} = $track->{composer}->{name} . string('COLON') . ' ' . $item->{work} if ($track->{composer}->{name});
 		$item->{work} = $track->{composer}->{name} . string('COLON') . ' ' . $item->{work} if ($track->{composer}->{name});
 		if ( $track->{composer}->{name} ) {
 			my $composerSurname = (split ' ', $track->{composer}->{name})[-1];
-			$item->{line1} =~ s/$composerSurname://;
+			$item->{line1} =~ s/\Q$composerSurname\E://;
 		}
 		$item->{line2} .= " - " . $item->{work} if $item->{work};
 	}

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -1243,11 +1243,10 @@ sub _trackItem {
 
 	# Enhancements to work/composer display for classical music (tags returned from Qobuz are all over the place)
 	my $genreList = $prefs->get('classicalGenres');
-	if ( 
-	    $prefs->get('useClassicalEnhancements')
-	    && 
-	    ( grep(/Classique/,@{$track->{album}->{genres_list}}) || grep(/(^\s*$genre\s*$|^\s*\*$)/,(split ',', $genreList )) ) 
-	   ) {
+	if ( $prefs->get('useClassicalEnhancements')
+		&& ( grep(/Classique/,@{$track->{album}->{genres_list}}) || grep(/(^\s*$genre\s*$|^\s*\*$)/,(split ',', $genreList )) ) 
+	   ) 
+	{
 		if ( $track->{work} ) {
 #			if ( $track->{work} ne $track->{title} ) {
 				$item->{work} = $track->{work};

--- a/ProtocolHandler.pm
+++ b/ProtocolHandler.pm
@@ -275,7 +275,16 @@ sub getMetadataFor {
 	if ( $meta->{isClassique} ) {
 		# if the title doesn't already contain the work text
 		if ( $meta->{work} && index($meta->{title},$meta->{work}) == -1 ) {
-			$meta->{title} =~ s/${\(split " ", $meta->{composer})[-1]}:\s*// if $meta->{composer};
+#			$meta->{title} =~ s/${\(split " ", $meta->{composer})[-1]}:\s*// if $meta->{composer};
+			# remove composer name from track title
+			if ( $meta->{composer} ) {
+				# full name
+				$meta->{title} =~ s/\Q$meta->{composer}\E:\s*//;
+				# surname only
+				my $composerSurname = (split " ", $meta->{composer})[-1];
+				$meta->{title} =~ s/\Q$composerSurname\E:\s*//;
+			}
+			
 			my $simpleWork = Slim::Utils::Text::ignoreCaseArticles(unidecode($meta->{work}), 1);
 			$simpleWork =~ s/\W//g;
 			my $simpleTitle = Slim::Utils::Text::ignoreCaseArticles(unidecode($meta->{title}), 1);

--- a/ProtocolHandler.pm
+++ b/ProtocolHandler.pm
@@ -10,6 +10,7 @@ use Text::Unidecode;
 use Slim::Utils::Log;
 use Slim::Utils::Misc;
 use Slim::Utils::Prefs;
+use Slim::Utils::Strings qw(string cstring);
 
 use Plugins::Qobuz::API;
 use Plugins::Qobuz::API::Common;
@@ -275,17 +276,17 @@ sub getMetadataFor {
 		# if the title doesn't already contain the work text
 		if ( $meta->{work} && index($meta->{title},$meta->{work}) == -1 ) {
 			$meta->{title} =~ s/${\(split " ", $meta->{composer})[-1]}:\s*// if $meta->{composer};
-			my $simpleWork = lc(unidecode($meta->{work}));
+			my $simpleWork = Slim::Utils::Text::ignoreCaseArticles(unidecode($meta->{work}), 1);
 			$simpleWork =~ s/\W//g;
-			my $simpleTitle = lc(unidecode($meta->{title}));
+			my $simpleTitle = Slim::Utils::Text::ignoreCaseArticles(unidecode($meta->{title}), 1);
 			$simpleTitle =~ s/\W//g;
 			if ( $simpleWork ne $simpleTitle ) {
-				$meta->{title} =  $meta->{work} . ': ' . $meta->{title};
+				$meta->{title} =  $meta->{work} . string('COLON') . ' ' . $meta->{title};
 			}
 		}
 		
 		if ( $meta->{composer} && index($meta->{title},(split " ", $meta->{composer})[-1]) == -1 ) {
-				$meta->{title} =  (split ' ', $meta->{composer})[-1] . ': ' . $meta->{title};
+			$meta->{title} =  (split " ", $meta->{composer})[-1] . string('COLON') . ' ' . $meta->{title};
 		}
 	}
 	

--- a/ProtocolHandler.pm
+++ b/ProtocolHandler.pm
@@ -269,10 +269,19 @@ sub getMetadataFor {
 
 	$meta->{title} = Plugins::Qobuz::API::Common->addVersionToTitle($meta);
 	
-	if ($meta->{work}) {
-		$meta->{title} = $meta->{work} . ': ' . $meta->{title};
+	my $genreList = $prefs->get('classicalGenres');
+	if (
+	    $prefs->get('useClassicalEnhancements') 
+	    && 
+	    ( grep(/Classique/,@{$meta->{genres_list}}) || grep(/(^\s*$meta->{genre}\s*$|^\s*\*$)/,(split ',', $genreList)) )
+	   ) {
+		if ( $meta->{work} && $meta->{work} ne $meta->{title} ) {
+			$meta->{title} =  $meta->{work} . ': ' . $meta->{title};
+		}
+		if ($meta->{composer} && (index($meta->{composer}, (split ':', $meta->{title})[0]) == -1) ) {
+			$meta->{title} =  (split ' ', $meta->{composer})[-1] . ': ' . $meta->{title};
+		}
 	}
-
 	return $meta;
 }
 

--- a/ProtocolHandler.pm
+++ b/ProtocolHandler.pm
@@ -270,11 +270,12 @@ sub getMetadataFor {
 	$meta->{title} = Plugins::Qobuz::API::Common->addVersionToTitle($meta);
 	
 	my $genreList = $prefs->get('classicalGenres');
-	if (
-	    $prefs->get('useClassicalEnhancements') 
-	    && 
-	    ( grep(/Classique/,@{$meta->{genres_list}}) || grep(/(^\s*$meta->{genre}\s*$|^\s*\*$)/,(split ',', $genreList)) )
-	   ) {
+	if ( $prefs->get('useClassicalEnhancements') 
+		&& ( grep(/Classique/,@{$meta->{genres_list}}) || grep(/(^\s*$meta->{genre}\s*$|^\s*\*$)/,(split ',', $genreList)) )
+			 # only proceed if the title doesn't already contain the work text and at least the composer's surname:
+			&& ( index($meta->{title},$meta->{work}) == -1 || index($meta->{title},(split " ", $meta->{composer})[-1] == -1) )
+	   ) 
+	{
 		if ( $meta->{work} && $meta->{work} ne $meta->{title} ) {
 			$meta->{title} =  $meta->{work} . ': ' . $meta->{title};
 		}

--- a/ProtocolHandler.pm
+++ b/ProtocolHandler.pm
@@ -275,7 +275,6 @@ sub getMetadataFor {
 	if ( $meta->{isClassique} ) {
 		# if the title doesn't already contain the work text
 		if ( $meta->{work} && index($meta->{title},$meta->{work}) == -1 ) {
-#			$meta->{title} =~ s/${\(split " ", $meta->{composer})[-1]}:\s*// if $meta->{composer};
 			# remove composer name from track title
 			if ( $meta->{composer} ) {
 				# full name

--- a/Settings.pm
+++ b/Settings.pm
@@ -21,7 +21,8 @@ sub page {
 
 sub prefs {
 	return ($prefs, 'filterSearchResults', 'playSamples', 'showComposerWithArtist', 'labelHiResAlbums', 'dontImportPurchases', 
-			'appendVersionToTitle', 'sortFavsAlphabetically', 'sortArtistAlbums', 'showYearWithAlbum', 'useClassicalEnhancements', 'classicalGenres');
+			'appendVersionToTitle', 'sortFavsAlphabetically', 'sortArtistAlbums', 'showYearWithAlbum', 'useClassicalEnhancements', 
+			'classicalGenres','workPlaylistPosition');
 }
 
 sub handler {

--- a/Settings.pm
+++ b/Settings.pm
@@ -21,7 +21,7 @@ sub page {
 
 sub prefs {
 	return ($prefs, 'filterSearchResults', 'playSamples', 'showComposerWithArtist', 'labelHiResAlbums', 'dontImportPurchases', 
-			'appendVersionToTitle', 'sortFavsAlphabetically', 'sortArtistAlbums', 'showYearWithAlbum');
+			'appendVersionToTitle', 'sortFavsAlphabetically', 'sortArtistAlbums', 'showYearWithAlbum', 'useClassicalEnhancements', 'classicalGenres');
 }
 
 sub handler {

--- a/strings.txt
+++ b/strings.txt
@@ -352,3 +352,20 @@ PLUGIN_QOBUZ_PROGRESS_READ_PLAYLISTS
 	EN	Fetching Playlists...
 	FR	Récupération des listes de lecture...
 	NL	Afspeellijsten ophalen...
+	
+PLUGIN_QOBUZ_USE_CLASSICAL_ENHANCEMENTS
+	EN	Enhanced display of classical works/composers
+
+PLUGIN_QOBUZ_USE_CLASSICAL_ENHANCEMENTS_DESC
+	EN	<br />Choose Yes if you want the plugin to use Qobuz data to attempt to:<br />* Show a playlist and subheadings for each work within a release<br />* Add the composer and work names to the track title in the playlist and now playing displays (the playlist cannot show subheadings)<br /><br />If you find a release for which the enhanced display does not show, add the Qobuz genre (shown in the release listing) to the "additional genres" list here (comma separated if more than one).<br /><br />For questions/bug reporting <a href="https://forums.slimdevices.com/forum/user-forums/3rd-party-software/94305-qobuz-com-streaming-plugin" target="_blank">visit the forum</a>.<br /><br /><b>Note:</b> for best results, use the "Material Skin" plugin. Otherwise, if using the default interface, do not use "large artwork" (option at bottom left of screen), the display will not be rendered well if you do. 
+	
+PLUGIN_QOBUZ_CLASSICAL_GENRES
+	EN	Additional genres:
+	
+PLUGIN_QOBUZ_DEFAULT_CLASSICAL_GENRES
+	CS	Klasika, Avantgarda, Baroko, Komorní hudba, Zpěv, Sbor, Klasický crossover, Raná hudba, Vrcholná klasika, Impresionismus, Středověk, Minimalismus, Moderní kompozice, Opera, Orchestr, Renesance, Romantika, Symfonie, Svatební hudba, Classical, Avant-Garde, Baroque, Chamber Music, Chant, Choral, Classical Crossover, Early Music, High Classical, Impressionist, Medieval, Minimalism, Modern Composition, Opera, Orchestral, Renaissance, Romantic, Symphony, Wedding Music
+	DE	Klassik, Avantgarde, Barok, Kammermusik, Choral, Klassik-Crossover, Hochklassik, Impressionist, Mittelalterlich, Minimalismus, Moderne Komposition, Oper, Orchester, Renaissance, Romantik, Symphonie, Hochzeitsmusik
+	EN	Classical, Avant-Garde, Baroque, Chamber Music, Chant, Choral, Classical Crossover, Early Music, High Classical, Impressionist, Medieval, Minimalism, Modern Composition, Opera, Orchestral, Renaissance, Romantic, Symphony, Wedding Music, Symphonies, Violin Concerto
+	FR	Musique de film, Classique, Musique concertante, Musique de chambre, Musique symphonique, Musique vocale, Opéra, Opérette, Musique de l'Antiquité, Musique du Moyen-Age, Musique de la Renaissance, Musique baroque, Musique classique, Musique romantique, Musique moderne, Musique contemporaine, Musique électronique ou concrète
+	NL	Klassiek, Avant-Garde, Barok, Kamermuziek, Zang, Koor, Klassieke Crossover, Oude muziek, Hoogklassiek, Impressionistisch, Jazz, Middeleeuws, Minimalisme, Moderne compositie, Opera, Orkest, Renaissance, Romantisch, Symfonie, Bruiloftsmuziek
+

--- a/strings.txt
+++ b/strings.txt
@@ -355,27 +355,45 @@ PLUGIN_QOBUZ_PROGRESS_READ_PLAYLISTS
 	
 PLUGIN_QOBUZ_USE_CLASSICAL_ENHANCEMENTS
 	EN	Enhanced classical music display
+	DE	Erweiterte Anzeige bei Werken des Genre Klassik
+	NL	Verbeterde weergave van klassieke werken/componisten
 
 PLUGIN_QOBUZ_USE_CLASSICAL_ENHANCEMENTS_DESC
-	EN	Choose Yes here if you want the plugin to use Qobuz data to attempt to:<br />* Show a playlist and subheadings for each composer/work within a release.<br />* Add the composer and work names to the track title in the playlist and now playing displays (the playlist cannot show subheadings).
+	EN	Choose Yes here if you want the plugin to use Qobuz data to attempt to: <br />* Show a playlist and subheadings for each composer/work within a release. <br />* Add the composer and work names to the track title in the playlist and now playing displays (the playlist cannot show subheadings).
+	DE	Wähle Ja, falls du Qobuz Daten nutzen willst, um folgendes zu erreichen: <br /> * Für jedes Werk einer Veröffentlichung eine Wiedergabeliste und Untertitel anzeigen. <br />* Komponisten - und Werkname für jeden Titel in der Wiedergabeliste und im "Now Playing" - Fenster anzeigen (Wiedergabelisten können keine Untertitel anzeigen).
+	NL	<br />Kies 'Ja' als je wilt dat de plug-in Qobuz-gegevens gebruikt om:<br />* Een afspeellijst en subkoppen voor elk werk binnen een release weer te geven<br />* De componist en werken toe te voegen aan de tracktitel in de afspeellijst en in de 'Speelt Nu' weergave (de afspeellijst kan geen subkoppen tonen).
 	
 PLUGIN_QOBUZ_CLASSICAL_GENRES
 	EN	Additional classical genres
+	DE	Zusätzliche Genres
+	NL	Additionele genres
 	
 PLUGIN_QOBUZ_CLASSICAL_GENRES_DESC
 	EN	If you find a release for which the enhanced display does not show, add the Qobuz genre (shown in the release listing) to the "additional genres" list here (comma separated if more than one).
+	DE	Falls für eine Veröffentlichung die Erweiterte Anzeige nicht funktioniert, dann füge das Qobuz Genre (zu finden im Inhaltsverzeichnis der Veröffentlichung ) zu der Liste "Zusätzliche Genres" (mehere Einträgen durch Kommata trennen).
+	NL	Als je een release vindt waarvoor de uitgebreide weergave niet wordt weergegeven, voeg dan het Qobuz-genre (weergegeven in de releaselijst) toe aan de "Additionele genres" (komma gescheiden indien meer dan één).
 	
 PLUGIN_QOBUZ_USE_CLASSICAL_ENHANCEMENTS_TEXT
-	EN	<br /><br />For questions/bug reporting <a href="https://forums.slimdevices.com/forum/user-forums/3rd-party-software/94305-qobuz-com-streaming-plugin" target="_blank">visit the forum</a>.<br /><br /><b>Note:</b> for best results, use the "Material Skin" plugin. Otherwise, if using the default interface, do not use "large artwork" (option at bottom left of screen), the display will not be rendered well if you do. 
+	EN	<br /><br />For questions/bug reporting <a href="https://forums.slimdevices.com/forum/user-forums/3rd-party-software/94305-qobuz-com-streaming-plugin" target="_blank">visit the forum</a>.<br /><br /><b>Note:</b> for best results, use the "Material Skin" plugin. Otherwise, if using the default interface, do not use "large artwork" (option at bottom left of screen), the display will not be rendered well if you do.
+	DE	<br /><br />Bei Fragen oder Melden von Fehlern: <a href="https://forums.slimdevices.com/forum/user-forums/3rd-party-software/94305-qobuz-com-streaming-plugin" target="_blank">visit the forum</a>.<br /><br /><b>Hinweis:</b> Nutze das Plugin "Material Skin" für die bestmögliche Darstellung. Bei der Web-Oberfläche "Standard" wird die Darstellung fehlerhaft, falls "Plattenhüllen anzeigen" ausgewählt wurde.
+	NL	<br /><br />Voor vragen/bugs <a href="https://forums.slimdevices.com/forum/user-forums/3rd-party-software/94305-qobuz-com-streaming-plugin" target="_blank">bezoek het forum</a>.<br /><br /><b>Opmerking:</b> gebruik voor de beste resultaten de plug-in "Material Skin". Als je de standaardinterface gebruikt, gebruik dan geen "grote albumhoes (optie linksonder op het scherm), de weergave zal dan niet goed worden weergegeven.	
 	
 PLUGIN_QOBUZ_WORK_PLAYLIST_POSITION
 	EN	Work playlist position
+	DE	Position für Wiedergabelisten
+	NL	Werk afspeellijst positie
 
 PLUGIN_QOBUZ_WORK_PLAYLIST_POSITION_BEFORE
 	EN	Before track list
+	DE	Vor der Titelliste
+	NL	Voor afspeellijst
 
 PLUGIN_QOBUZ_WORK_PLAYLIST_POSITION_AFTER
 	EN	After track list
+	DE	Nach der Titelliste
+	NL	Na afspeellijst
 
 PLUGIN_QOBUZ_WORK_PLAYLIST_POSITION_HIDDEN
 	EN	Do not show
+	DE	Nicht Anzeigen
+	NL	Niet tonen

--- a/strings.txt
+++ b/strings.txt
@@ -354,13 +354,19 @@ PLUGIN_QOBUZ_PROGRESS_READ_PLAYLISTS
 	NL	Afspeellijsten ophalen...
 	
 PLUGIN_QOBUZ_USE_CLASSICAL_ENHANCEMENTS
-	EN	Enhanced display of classical works/composers
+	EN	Enhanced classical music display
 
 PLUGIN_QOBUZ_USE_CLASSICAL_ENHANCEMENTS_DESC
-	EN	<br />Choose Yes if you want the plugin to use Qobuz data to attempt to:<br />* Show a playlist and subheadings for each work within a release<br />* Add the composer and work names to the track title in the playlist and now playing displays (the playlist cannot show subheadings)<br /><br />If you find a release for which the enhanced display does not show, add the Qobuz genre (shown in the release listing) to the "additional genres" list here (comma separated if more than one).<br /><br />For questions/bug reporting <a href="https://forums.slimdevices.com/forum/user-forums/3rd-party-software/94305-qobuz-com-streaming-plugin" target="_blank">visit the forum</a>.<br /><br /><b>Note:</b> for best results, use the "Material Skin" plugin. Otherwise, if using the default interface, do not use "large artwork" (option at bottom left of screen), the display will not be rendered well if you do. 
+	EN	Choose Yes here if you want the plugin to use Qobuz data to attempt to:<br />* Show a playlist and subheadings for each composer/work within a release.<br />* Add the composer and work names to the track title in the playlist and now playing displays (the playlist cannot show subheadings).
 	
 PLUGIN_QOBUZ_CLASSICAL_GENRES
-	EN	Additional genres:
+	EN	Additional classical genres
+	
+PLUGIN_QOBUZ_CLASSICAL_GENRES_DESC
+	EN	If you find a release for which the enhanced display does not show, add the Qobuz genre (shown in the release listing) to the "additional genres" list here (comma separated if more than one).
+	
+PLUGIN_QOBUZ_USE_CLASSICAL_ENHANCEMENTS_TEXT
+	EN	<br /><br />For questions/bug reporting <a href="https://forums.slimdevices.com/forum/user-forums/3rd-party-software/94305-qobuz-com-streaming-plugin" target="_blank">visit the forum</a>.<br /><br /><b>Note:</b> for best results, use the "Material Skin" plugin. Otherwise, if using the default interface, do not use "large artwork" (option at bottom left of screen), the display will not be rendered well if you do. 
 	
 PLUGIN_QOBUZ_DEFAULT_CLASSICAL_GENRES
 	CS	Klasika, Avantgarda, Baroko, Komorní hudba, Zpěv, Sbor, Klasický crossover, Raná hudba, Vrcholná klasika, Impresionismus, Středověk, Minimalismus, Moderní kompozice, Opera, Orchestr, Renesance, Romantika, Symfonie, Svatební hudba, Classical, Avant-Garde, Baroque, Chamber Music, Chant, Choral, Classical Crossover, Early Music, High Classical, Impressionist, Medieval, Minimalism, Modern Composition, Opera, Orchestral, Renaissance, Romantic, Symphony, Wedding Music

--- a/strings.txt
+++ b/strings.txt
@@ -368,10 +368,14 @@ PLUGIN_QOBUZ_CLASSICAL_GENRES_DESC
 PLUGIN_QOBUZ_USE_CLASSICAL_ENHANCEMENTS_TEXT
 	EN	<br /><br />For questions/bug reporting <a href="https://forums.slimdevices.com/forum/user-forums/3rd-party-software/94305-qobuz-com-streaming-plugin" target="_blank">visit the forum</a>.<br /><br /><b>Note:</b> for best results, use the "Material Skin" plugin. Otherwise, if using the default interface, do not use "large artwork" (option at bottom left of screen), the display will not be rendered well if you do. 
 	
-PLUGIN_QOBUZ_DEFAULT_CLASSICAL_GENRES
-	CS	Klasika, Avantgarda, Baroko, Komorní hudba, Zpěv, Sbor, Klasický crossover, Raná hudba, Vrcholná klasika, Impresionismus, Středověk, Minimalismus, Moderní kompozice, Opera, Orchestr, Renesance, Romantika, Symfonie, Svatební hudba, Classical, Avant-Garde, Baroque, Chamber Music, Chant, Choral, Classical Crossover, Early Music, High Classical, Impressionist, Medieval, Minimalism, Modern Composition, Opera, Orchestral, Renaissance, Romantic, Symphony, Wedding Music
-	DE	Klassik, Avantgarde, Barok, Kammermusik, Choral, Klassik-Crossover, Hochklassik, Impressionist, Mittelalterlich, Minimalismus, Moderne Komposition, Oper, Orchester, Renaissance, Romantik, Symphonie, Hochzeitsmusik
-	EN	Classical, Avant-Garde, Baroque, Chamber Music, Chant, Choral, Classical Crossover, Early Music, High Classical, Impressionist, Medieval, Minimalism, Modern Composition, Opera, Orchestral, Renaissance, Romantic, Symphony, Wedding Music, Symphonies, Violin Concerto
-	FR	Musique de film, Classique, Musique concertante, Musique de chambre, Musique symphonique, Musique vocale, Opéra, Opérette, Musique de l'Antiquité, Musique du Moyen-Age, Musique de la Renaissance, Musique baroque, Musique classique, Musique romantique, Musique moderne, Musique contemporaine, Musique électronique ou concrète
-	NL	Klassiek, Avant-Garde, Barok, Kamermuziek, Zang, Koor, Klassieke Crossover, Oude muziek, Hoogklassiek, Impressionistisch, Jazz, Middeleeuws, Minimalisme, Moderne compositie, Opera, Orkest, Renaissance, Romantisch, Symfonie, Bruiloftsmuziek
+PLUGIN_QOBUZ_WORK_PLAYLIST_POSITION
+	EN	Work playlist position
 
+PLUGIN_QOBUZ_WORK_PLAYLIST_POSITION_BEFORE
+	EN	Before track list
+
+PLUGIN_QOBUZ_WORK_PLAYLIST_POSITION_AFTER
+	EN	After track list
+
+PLUGIN_QOBUZ_WORK_PLAYLIST_POSITION_HIDDEN
+	EN	Do not show


### PR DESCRIPTION
New plugin options to enable display of classical works/composers.

The display is controlled by the Qobuz tag genre_list: if this array contains the element "Classique" and the user has enabled "Enhanced classical music display" in the options, subheadings will be created for each composer/work in the release, and the titles of tracks added to the play queue/now playing will have the composer and work prepended.

There is also an option for the user to control the playlists that are created in the listing for each work: they can appear before the individual tracks (this is the default), after the individual tracks, or not at all. 

If the user finds a release which is not tagged "Classique" (see above), but would nonetheless benefit from these enhancements, there is an option for them to add the genre to a list in their plugin settings.

Finally, various string manipulation has been implemented to try to clean up the somewhat inconsistent composer/work/title tags returned by Qobuz.

Note that these affect Qobuz listings and the play queue/now playing displays only. There is no change to the data sent to the user's library by the online music import.

Many thanks to SamY for starting this work, and his testing and encouragement.