### PR TITLE
Ensure tracks in the same work are grouped even if composer metadata is missing from some.

### DIFF
--- a/Plugin.pm
+++ b/Plugin.pm
@@ -949,7 +949,8 @@ sub QobuzGetTracks {
 		my $works = {};
 		my $lastwork = "";
 		my $worksfound = 0;
-		my $containsUnstreamable = 0;
+		my $noComposer = 0;
+		my $workHeadingPos = 0;
 		
 		foreach my $track (@{$album->{tracks}->{items}}) {
 			$totalDuration += $track->{duration};
@@ -960,26 +961,31 @@ sub QobuzGetTracks {
 				my $workId = Slim::Utils::Text::matchCase(Slim::Utils::Text::ignorePunct($work));
 				$workId =~ s/\s//g;
 
-				$works->{$workId} = {
+				$works->{$workId} = {   # create a new work object
 					index => $i,
-					title => $work,
-					image => $formattedTrack->{image},
+					title => $formattedTrack->{displayWork},
 					tracks => []
 				} unless $works->{$workId};
 				
 				if ($workId ne $lastwork) {  # create a new work heading
-					push @$items,{
-						name  => $work,
+					$workHeadingPos = push @$items,{
 						name  => $formattedTrack->{displayWork},
 						type  => 'text'
 					};
-						
+					
+					$noComposer = !$track->{composer}->{name};
 					$lastwork = $workId;
 				}
 				
 				push @{$works->{$workId}->{tracks}}, $formattedTrack;
 				if (scalar @{$works->{$workId}->{tracks}} > 1) {
 					$worksfound = 1;   # we found a work with more than one track
+				}
+				
+				if ($noComposer && $track->{composer}->{name} && $workHeadingPos) {  #add composer to work title if needed
+					@$items[$workHeadingPos-1]->{name} = $formattedTrack->{displayWork};
+					$works->{$workId}->{title} = $formattedTrack->{displayWork};
+					$noComposer = 0;
 				}
 			} elsif ($lastwork ne "") {  # create a separator line for tracks without a work
 				push @$items,{
@@ -988,11 +994,13 @@ sub QobuzGetTracks {
 				};
 						
 				$lastwork = "";
+				$noComposer = 0;
 			}	
 
 			$i++;
 
 			push @$items, $formattedTrack;
+			
 		}
 
 		if (scalar keys %$works) {
@@ -1274,7 +1282,6 @@ sub _trackItem {
 		}
 		$item->{displayWork} = $item->{work};
 		$item->{displayWork} = $track->{composer}->{name} . string('COLON') . ' ' . $item->{work} if ($track->{composer}->{name});
-		$item->{work} = $track->{composer}->{name} . string('COLON') . ' ' . $item->{work} if ($track->{composer}->{name});
 		if ( $track->{composer}->{name} ) {
 			my $composerSurname = (split ' ', $track->{composer}->{name})[-1];
 			$item->{line1} =~ s/\Q$composerSurname\E://;

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -1304,6 +1304,7 @@ sub _trackItem {
 			name => cstring($client, 'PLUGIN_QOBUZ_NOT_AVAILABLE'),
 			type => 'textarea'
 		}];
+		$item->{line1}     = '* ' . $item->{line1};
 	}
 	else {
 		$item->{name}      = '* ' . $item->{name} if !$track->{streamable};


### PR DESCRIPTION
For some reason, Qobuz does not populate the composer tag for classical tracks that are tagged as unavailable for streaming. This prevents them from being included in the 'work' object to which they belong in the plugin, which is keyed on composer and work. Instead, they are added to separate works, keyed on the work name only, which is confusing. Fortunately there are not a whole lot of releases containing these tracks, but enough to bother someone with a low threshold of annoyance such as myself.  ;-)  This change groups these tracks with the others in same work.