### PR TITLE
Allow orphaned album favorites to be removed.

### DIFF
--- a/Plugin.pm
+++ b/Plugin.pm
@@ -940,8 +940,8 @@ sub QobuzGetTracks {
 		my $album = shift;
 		my $items = [];
 
-		if (!$album) {						
-			$log->warn("Get album ($albumId) failed");					
+		if (!$album) {
+			$log->warn("Get album ($albumId) failed");
 			Plugins::Qobuz::API->getUserFavorites(sub {
 				my $favorites = shift;
 				my $isFavorite = ($favorites && $favorites->{albums}) ? grep { $_->{id} eq $albumId } @{$favorites->{albums}->{items}} : 0;

--- a/strings.txt
+++ b/strings.txt
@@ -397,3 +397,9 @@ PLUGIN_QOBUZ_WORK_PLAYLIST_POSITION_HIDDEN
 	EN	Do not show
 	DE	Nicht Anzeigen
 	NL	Niet tonen
+	
+PLUGIN_QOBUZ_ALBUM_NOT_FOUND
+	EN	Album not found in the Qobuz library
+	DE	Album nicht in der Qobuz-Bibliothek gefunden
+	NL	Album niet gevonden in de Qobuz bibliotheek
+	FR	Album introuvable dans la bibliothèque Qobuz


### PR DESCRIPTION
This change allows album favorites whose associated album id's are not found in the Qobuz library to be removed via the Album Favorites menu, saving the user from having to perform the task in the Qobuz app.