### PR TITLE
Change how unstreamable albums are handled

### DIFF
--- a/Plugin.pm
+++ b/Plugin.pm
@@ -1241,9 +1241,10 @@ sub _albumItem {
 	if ( $album->{released_at} > time || !$album->{streamable}) {
 		$item->{name}  = '* ' . $item->{name};
 		$item->{line1} = '* ' . $item->{line1};
+	} else {	
+		$item->{type}        = 'playlist';
 	}
 	
-	$item->{type}        = 'playlist';
 	$item->{url}         = \&QobuzGetTracks;
 	$item->{passthrough} = [{
 		album_id => $album->{id},

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -1005,7 +1005,7 @@ sub QobuzGetTracks {
 			my $formattedTrack = _trackItem($client, $track);
 			my $work = delete $formattedTrack->{work};
 			
-			if ( $work && ($workPlaylistPos ne "hidden") ) {
+			if ( $work ) {
 				# Qobuz sometimes would f... up work names, randomly putting whitespace etc. in names - ignore them
 				my $workId = Slim::Utils::Text::matchCase(Slim::Utils::Text::ignorePunct($work));
 				$workId =~ s/\s//g;

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -940,7 +940,7 @@ sub QobuzGetTracks {
 		my $album = shift;
 		my $items = [];
 
-		if (!$album) {
+		if (!$album) {  # the album does not exist in the Qobuz library
 			$log->warn("Get album ($albumId) failed");
 			Plugins::Qobuz::API->getUserFavorites(sub {
 				my $favorites = shift;
@@ -951,7 +951,7 @@ sub QobuzGetTracks {
 					type  => 'text'						
 				};
 				
-				if ($isFavorite) {
+				if ($isFavorite) {  # if it's an orphaned favorite, let the user delete it
 					push @$items, {
 						name => cstring($client, 'PLUGIN_QOBUZ_REMOVE_FAVORITE', $albumTitle),
 						url  => \&QobuzDeleteFavorite,
@@ -968,8 +968,30 @@ sub QobuzGetTracks {
 				}, @_ );
 			});
 			return;
-		}			
-
+			
+		} elsif ($album->{released_at} > time ) {  # the album has not been released yet
+			push @$items, {
+				name  => cstring($client, 'PLUGIN_QOBUZ_NOT_RELEASED') . ' (' . Slim::Utils::DateTime::shortDateF($album->{released_at}) . ')',
+				type  => 'text'						
+			};
+			
+			$cb->({
+				items => $items,
+			}, @_ );
+			return;
+			
+		} elsif (!$album->{streamable} && !$prefs->get('playSamples')) {  # the album is not streamable
+			push @$items, {
+				name  => cstring($client, 'PLUGIN_QOBUZ_NOT_AVAILABLE'),
+				type  => 'text'						
+			};
+			
+			$cb->({
+				items => $items,
+			}, @_ );
+			return;
+		}
+		
 		my $totalDuration = my $i = 0;
 		my $works = {};
 		my $lastwork = "";
@@ -1216,25 +1238,18 @@ sub _albumItem {
 		$item->{name} .= $albumYear ? "\n(" . $albumYear . ')' : '';
 	}
 
-	if ( $album->{released_at} > time  || (!$album->{streamable} && !$prefs->get('playSamples')) ) {
-		my $sorry = ' (' . cstring($client, 'PLUGIN_QOBUZ_NOT_AVAILABLE') . ')';
-		$item->{name}  .= $sorry;
-		$item->{line2} .= $sorry;
-		delete $item->{type};
-		$item->{type} = 'text';
-		delete $item->{url};
+	if ( $album->{released_at} > time || !$album->{streamable}) {
+		$item->{name}  = '* ' . $item->{name};
+		$item->{line1} = '* ' . $item->{line1};
 	}
-	else {
-		$item->{name}        = '* ' . $item->{name} if !$album->{streamable};
-		$item->{line1}       = '* ' . $item->{line1} if !$album->{streamable};
-		$item->{type}        = 'playlist';
-		$item->{url}         = \&QobuzGetTracks;
-		$item->{passthrough} = [{
-			album_id => $album->{id},
-			album_title => $album->{title},
-		}];
-	}
-
+	
+	$item->{type}        = 'playlist';
+	$item->{url}         = \&QobuzGetTracks;
+	$item->{passthrough} = [{
+		album_id => $album->{id},
+		album_title => $album->{title},
+	}];
+	
 	return $item;
 }
 
@@ -1322,7 +1337,7 @@ sub _trackItem {
 		$item->{year} = $track->{album}->{year} || (localtime($track->{album}->{released_at}))[5] + 1900 || 0;
 	}
 
-	if ($track->{album} && $track->{album}->{released_at} && $track->{album}->{released_at} > time) {
+	if ($track->{released_at} > time) {
 		$item->{items} = [{
 			name => cstring($client, 'PLUGIN_QOBUZ_NOT_RELEASED'),
 			type => 'textarea'


### PR DESCRIPTION
Allow unstreamable albums to be clicked through to an informational screen, where any relevant messages are then displayed. The "*" is still prepended to the album title in the album list, indicating that the title is either not yet released or tagged as unstreamable. The details are shown on the subsequent screen. In the case of not-yet-released titles, the date when it is scheduled for release is also shown.