### PR TITLE
Handle genre correctly when not browsing by album

### DIFF
--- a/ProtocolHandler.pm
+++ b/ProtocolHandler.pm
@@ -297,7 +297,12 @@ sub getMetadataFor {
 			$meta->{title} =  (split " ", $meta->{composer})[-1] . string('COLON') . ' ' . $meta->{title};
 		}
 	}
-	
+
+	# When the user is not browsing via album, genre is a map, not a simple string. Check for this and correct it. 
+	if ( ref $meta->{genre} ne "" ) {
+		$meta->{genre} = $meta->{genre}->{name};
+	}
+
 	return $meta;
 }
 


### PR DESCRIPTION
When not adding tracks to the playlist via the album, $meta->genre ends up being a map (with strange elements like "color"!) rather than a simple string. This fixes that.