### PR TITLE
Improve handling and display of album release dates

### DIFF
--- a/API/Common.pm
+++ b/API/Common.pm
@@ -91,9 +91,8 @@ sub filterPlayables {
 
 	return $items if $prefs->get('playSamples');
 
-	my $t = time;
 	return [ grep {
-		($_->{released_at} ? $_->{released_at} <= $t : 1) && $_->{streamable};
+		!$_->{released_at} || $_->{streamable};  # allow all tracks and streamable albums
 	} @$items ];
 }
 
@@ -130,7 +129,7 @@ sub _precacheAlbum {
 			id     => $album->{id},
 			artist => $album->{artist},
 			image  => $album->{image},
-			year   => (localtime($album->{released_at}))[5] + 1900,
+			year   => substr($album->{release_date_stream},0,4),
 			goodies=> $album->{goodies},
 			genre  => $album->{genre},
 			genres_list => $album->{genres_list},
@@ -186,7 +185,7 @@ sub precacheTrack {
 		performers => $track->{performers} || '',
 		cover    => $album->{image},
 		duration => $track->{duration} || 0,
-		year     => $album->{year} || (localtime($album->{released_at}))[5] + 1900 || 0,
+		year     => $album->{year} || substr($album->{release_date_stream},0,4) || 0,
 		goodies  => $album->{goodies},
 		version  => $track->{version},
 		work     => $track->{work},

--- a/Importer.pm
+++ b/Importer.pm
@@ -349,7 +349,7 @@ sub _prepareTrack {
 		DISC         => $track->{media_number},
 		DISCC        => $album->{media_count},
 		SECS         => $track->{duration},
-		YEAR         => (localtime($album->{released_at}))[5] + 1900,
+		YEAR         => substr($album->{release_date_stream},0,4),
 		COVER        => $album->{image},
 		AUDIO        => 1,
 		EXTID        => $url,

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -5,6 +5,7 @@ use base qw(Slim::Plugin::OPMLBased);
 
 use JSON::XS::VersionOneAndTwo;
 use Tie::RegexpHash;
+use POSIX qw(strftime);
 
 use Slim::Formats::RemoteMetadata;
 use Slim::Player::ProtocolHandlers;
@@ -982,8 +983,10 @@ sub QobuzGetTracks {
 		}
 
 		if (!_isReleased($album) ) {
+			my @dt = split(/-/, $album->{release_date_stream});
+			my $rDate = strftime(preferences('server')->get('shortdateFormat'), 0, 0, 0, $dt[2], $dt[1] - 1, $dt[0] - 1900);
 			push @$items, {
-				name  => cstring($client, 'PLUGIN_QOBUZ_NOT_RELEASED') . ' (' . $album->{release_date_stream} . ')',
+				name  => cstring($client, 'PLUGIN_QOBUZ_NOT_RELEASED') . ' (' . $rDate . ')',
 				type  => 'text'						
 			};
 		}
@@ -1125,8 +1128,10 @@ sub QobuzGetTracks {
 				push @$items, $item;
 			}
 
+			my @dt = split(/-/, $album->{release_date_stream});
+			my $rDate = strftime(preferences('server')->get('shortdateFormat'), 0, 0, 0, $dt[2], $dt[1] - 1, $dt[0] - 1900);
 			push @$items, {
-				name  => cstring($client, 'PLUGIN_QOBUZ_RELEASED_AT') . cstring($client, 'COLON') . ' ' . $album->{release_date_stream},
+				name  => cstring($client, 'PLUGIN_QOBUZ_RELEASED_AT') . cstring($client, 'COLON') . ' ' . $rDate,
 				type  => 'text'
 			};
 
@@ -1210,7 +1215,7 @@ sub _albumItem {
 	my $artist = $album->{artist}->{name} || '';
 	my $albumName = $album->{title} || '';
 	my $showYearWithAlbum = $prefs->get('showYearWithAlbum');
-	my $albumYear = $showYearWithAlbum ? $album->{year} || (localtime($album->{released_at}))[5] + 1900 || 0 : 0;
+	my $albumYear = $showYearWithAlbum ? $album->{year} || substr($album->{release_date_stream},0,4) || 0 : 0;
 
 	if ( $album->{hires_streamable} && $albumName !~ /hi.?res|bits|khz/i && $prefs->get('labelHiResAlbums') && Plugins::Qobuz::API::Common->getStreamingFormat($album) eq 'flac' ) {
 		$albumName .= ' (' . cstring($client, 'PLUGIN_QOBUZ_HIRES') . ')';
@@ -1331,7 +1336,7 @@ sub _trackItem {
 	}
 
 	if ( $track->{album} ) {
-		$item->{year} = $track->{album}->{year} || (localtime($track->{album}->{released_at}))[5] + 1900 || 0;
+		$item->{year} = $track->{album}->{year} || substr($track->{$album}->{release_date_stream},0,4) || 0;
 	}
 	
 	if (!$track->{streamable} && (!$prefs->get('playSamples') || !$track->{sampleable})) {

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -983,8 +983,7 @@ sub QobuzGetTracks {
 		}
 
 		if (!_isReleased($album) ) {
-			my @dt = split(/-/, $album->{release_date_stream});
-			my $rDate = strftime(preferences('server')->get('shortdateFormat'), 0, 0, 0, $dt[2], $dt[1] - 1, $dt[0] - 1900);
+			my $rDate = _localDate($album->{release_date_stream});
 			push @$items, {
 				name  => cstring($client, 'PLUGIN_QOBUZ_NOT_RELEASED') . ' (' . $rDate . ')',
 				type  => 'text'						
@@ -1128,8 +1127,7 @@ sub QobuzGetTracks {
 				push @$items, $item;
 			}
 
-			my @dt = split(/-/, $album->{release_date_stream});
-			my $rDate = strftime(preferences('server')->get('shortdateFormat'), 0, 0, 0, $dt[2], $dt[1] - 1, $dt[0] - 1900);
+			my $rDate = _localDate($album->{release_date_stream});
 			push @$items, {
 				name  => cstring($client, 'PLUGIN_QOBUZ_RELEASED_AT') . cstring($client, 'COLON') . ' ' . $rDate,
 				type  => 'text'
@@ -1707,6 +1705,12 @@ sub _isReleased {  # determine if the referenced album has been released
 		my $ldate = Slim::Utils::DateTime::shortDateF($ltime, "%Y-%m-%d");
 		return ($ldate ge $album->{release_date_stream});
 	}
+}
+
+sub _localDate {  # convert input date string in format YYYY-MM-DD to localized short date format
+	my $iDate = shift;
+	my @dt = split(/-/, $iDate);
+	return strftime(preferences('server')->get('shortdateFormat'), 0, 0, 0, $dt[2], $dt[1] - 1, $dt[0] - 1900);
 }
 
 1;

--- a/strings.txt
+++ b/strings.txt
@@ -198,10 +198,10 @@ PLUGIN_QOBUZ_PLAY_SAMPLES
 	NL	Sample afspelen
 
 PLUGIN_QOBUZ_PLAY_SAMPLES_DESC
-	DE	Manche Musikstücke sind nicht zum online-Hören verfügbar. In diesen Fällen kann jedoch ein 60-Sekunden Hörprobe abgespielt werden. Diese werden mit einem * im Titel gekennzeichnet.
-	EN	Some tracks are not available for streaming. Should the 60 seconds sample be played instead? These titles will be labeled with an asterisk (*).
-	FR	Certains albums sont uniquement disponibles à l'achat en téléchargement : le détenteur des droits ne souhaite pas qu'il soit disponible en streaming. Voulez-vous écouter des extraits de 60 secondes ?
-	NL	Sommige nummers zijn niet beschikbaar voor streaming. In plaats daarvan kan een sample van 60 seconden worden gespeeld. Deze worden aangegeven met een asterisk (*).
+	DE	Manche Musikstücke sind nicht zum online-Hören verfügbar. In diesen Fällen kann jedoch ein 30-Sekunden Hörprobe abgespielt werden. Diese werden mit einem * im Titel gekennzeichnet.
+	EN	Some tracks are not available for streaming. Should the 30-second sample be played instead? These titles will be labeled with an asterisk (*).
+	FR	Certains albums sont uniquement disponibles à l'achat en téléchargement : le détenteur des droits ne souhaite pas qu'il soit disponible en streaming. Voulez-vous écouter des extraits de 30 secondes ?
+	NL	Sommige nummers zijn niet beschikbaar voor streaming. In plaats daarvan kan een sample van 30 seconden worden gespeeld. Deze worden aangegeven met een asterisk (*).
 
 PLUGIN_QOBUZ_LABEL_HIRES
 	DE	Hi-Res Alben als solche markieren


### PR DESCRIPTION
These changes simplify how the release date and year are calculated and displayed, removing discrepancies  between the YEAR tag and the release date in time zones east of France for albums released on January 1, among other things. It also now displays album release dates using the local date format. Note: It would be nice to have a version of Slim::Utils:DateTime::shortDateF() that took a localtime structure instead of an epoch time as an argument.

The change to strings.txt corrects the statement that sample tracks are 60 seconds. They are now 30 seconds.

Albums that are not yet released but streamable due to having one or more pre-released playable tracks are no longer filtered out in Common.pm when the user has chosen not to play 30-second sample tracks, allowing those albums to be shown and the pre-release tracks to be played.