### PR TITLE
Re-add Squeezer to list of clients supporting Weblinks

### DIFF
--- a/Plugin.pm
+++ b/Plugin.pm
@@ -22,7 +22,7 @@ use constant CLICOMMAND => 'qobuzquery';
 use constant MAX_RECENT => 30;
 
 # Keep in sync with Music & Artist Information plugin
-my $WEBLINK_SUPPORTED_UA_RE = qr/\b(?:iPeng|SqueezePad|OrangeSqueeze|OpenSqueeze|Squeeze-Control)\b/i;
+my $WEBLINK_SUPPORTED_UA_RE = qr/\b(?:iPeng|SqueezePad|OrangeSqueeze|OpenSqueeze|Squeezer|Squeeze-Control)\b/i;
 my $WEBBROWSER_UA_RE = qr/\b(?:FireFox|Chrome|Safari)\b/i;
 
 my $GOODIE_URL_PARSER_RE = qr/\.(?:pdf|png|gif|jpg)$/i;


### PR DESCRIPTION
See https://github.com/kaaholst/android-squeezer/issues/799.   Verified with latest version of Squeezer on 6/26/23.