### PR TITLE
Change stream quality selection

### DIFF
--- a/API.pm
+++ b/API.pm
@@ -494,12 +494,12 @@ sub getFileInfo {
 
 	if ($format =~ /fl.c/i) {
 		$preferredFormat = $prefs->get('preferredFormat');
-		if ($preferredFormat < QOBUZ_STREAMING_FLAC_HIRES || ($maxSupportedSamplerate && $maxSupportedSamplerate < 48_000)) {
-			$preferredFormat = QOBUZ_STREAMING_FLAC;
+		if ($preferredFormat < QOBUZ_STREAMING_FLAC_96000 || ($maxSupportedSamplerate && $maxSupportedSamplerate < 48_000)) {
+			$preferredFormat = QOBUZ_STREAMING_44100;
 		}
-		elsif ($preferredFormat > QOBUZ_STREAMING_FLAC_HIRES) {
+		elsif ($preferredFormat > QOBUZ_STREAMING_FLAC_96000) {
         		if ($maxSupportedSamplerate && $maxSupportedSamplerate <= 96_000) {
-				$preferredFormat = QOBUZ_STREAMING_FLAC_HIRES;
+				$preferredFormat = QOBUZ_STREAMING_FLAC_96000;
 			}
 		}
 	}

--- a/API.pm
+++ b/API.pm
@@ -494,12 +494,12 @@ sub getFileInfo {
 
 	if ($format =~ /fl.c/i) {
 		$preferredFormat = $prefs->get('preferredFormat');
-		if ($preferredFormat < QOBUZ_STREAMING_FLAC_96000 || ($maxSupportedSamplerate && $maxSupportedSamplerate < 48_000)) {
-			$preferredFormat = QOBUZ_STREAMING_44100;
+		if ($preferredFormat < QOBUZ_STREAMING_FLAC_HIRES || ($maxSupportedSamplerate && $maxSupportedSamplerate < 48_000)) {
+			$preferredFormat = QOBUZ_STREAMING_FLAC;
 		}
-		elsif ($preferredFormat > QOBUZ_STREAMING_FLAC_96000) {
+		elsif ($preferredFormat > QOBUZ_STREAMING_FLAC_HIRES) {
         		if ($maxSupportedSamplerate && $maxSupportedSamplerate <= 96_000) {
-				$preferredFormat = QOBUZ_STREAMING_FLAC_96000;
+				$preferredFormat = QOBUZ_STREAMING_FLAC_HIRES;
 			}
 		}
 	}

--- a/API.pm
+++ b/API.pm
@@ -498,7 +498,7 @@ sub getFileInfo {
 			$preferredFormat = QOBUZ_STREAMING_FLAC;
 		}
 		elsif ($preferredFormat > QOBUZ_STREAMING_FLAC_HIRES) {
-        		if ($maxSupportedSamplerate && $maxSupportedSamplerate <= 96_000) {
+			if ($maxSupportedSamplerate && $maxSupportedSamplerate <= 96_000) {
 				$preferredFormat = QOBUZ_STREAMING_FLAC_HIRES;
 			}
 		}

--- a/API.pm
+++ b/API.pm
@@ -494,11 +494,13 @@ sub getFileInfo {
 
 	if ($format =~ /fl.c/i) {
 		$preferredFormat = $prefs->get('preferredFormat');
-		if ($preferredFormat < QOBUZ_STREAMING_FLAC_HIRES || ($maxSupportedSamplerate && $maxSupportedSamplerate <= 48_000)) {
+		if ($preferredFormat < QOBUZ_STREAMING_FLAC_HIRES || ($maxSupportedSamplerate && $maxSupportedSamplerate < 48_000)) {
 			$preferredFormat = QOBUZ_STREAMING_FLAC;
 		}
 		elsif ($preferredFormat > QOBUZ_STREAMING_FLAC_HIRES) {
-			$preferredFormat = QOBUZ_STREAMING_FLAC_HIRES2;
+        		if ($maxSupportedSamplerate && $maxSupportedSamplerate <= 96_000) {
+				$preferredFormat = QOBUZ_STREAMING_FLAC_HIRES;
+			}
 		}
 	}
 	elsif ($format =~ /mp3/i) {


### PR DESCRIPTION
Changed stream selection logic:

When the user preference is hi-res 96K, we'll stream up to 96K for all players capable of 48K and up.  The server will transcode if necessary for 48K players. (previously, we'd use the 16/44.1 stream for 48K players).

When the user preference is hi-res >96K, we'll stream up to 96K for players capable of 48K and 96K (server will transcode if necessary as above). And we'll stream up to 192K for players capable of 192K. (previously, we'd use a >96K stream for 96K players, with the server transcoding).

Tested with SB3 (48K player), Touch (96K player) and UPnPBridge->WiiM Mini (192K player).