### PR TITLE
Fix problem jumping forward and back within a playing song.

### DIFF
--- a/ProtocolHandler.pm
+++ b/ProtocolHandler.pm
@@ -245,6 +245,7 @@ sub parseDirectHeaders {
 	# try to calculate exact bitrate so we can display correct progress
 	my $meta = $class->getMetadataFor($client, $url);
 	my $duration = $meta->{duration};
+	my $offset = $song->seekdata() ? $song->seekdata()->{'timeOffset'} : 0;
 
 	# sometimes we only get a 30s/mp3 sample
 	if ($meta->{streamable} && $meta->{streamable} eq 'sample' && $contentType eq 'mp3') {
@@ -254,7 +255,7 @@ sub parseDirectHeaders {
 	$song->duration($duration);
 
 	if ($length && $contentType eq 'flc') {
-		$bitrate = $length*8 / $duration if $duration;
+		$bitrate = $length*8 / ($duration - $offset) if $duration;
 		$song->bitrate($bitrate) if $bitrate;
 	}
 


### PR DESCRIPTION
This has been bothering me for a long time. It took awhile to figure out what was happening but, as you can see, the fix was very simple. The problem was that the bitrate would get corrupted every time a jump forward or backward was done, which caused any subsequent jumps to end up in the wrong place and further corrupt the bitrate, since the target of each jump is dependent on the bitrate. In other words, it was a mess. In my testing, I was able to jump forward and backward accurately within a song and even jump to a few seconds before the end of a gapless track while preserving the "gaplessness".