### PR TITLE
Return 'undef' from trackGain() if RG not in use.

### DIFF
--- a/ProtocolHandler.pm
+++ b/ProtocolHandler.pm
@@ -156,7 +156,7 @@ sub trackGain {
  	my $rgmode = preferences('server')->client($client)->get('replayGainMode');
 
 	if ( $rgmode == 0 ) {  # no replay gain
-		return 0;
+		return undef;
 	}
 
 	my $cache = Plugins::Qobuz::API::Common->getCache();


### PR DESCRIPTION
Return 'undef' from call to trackGain() if Replay Gain is not in use for the player, in accordance with the LMS fetchGainMode() function. This allows the client app to accurately distinguish a track gain value of '0' from the situation where RG is turned off.