### PR TITLE
Improvements to replay gain.

### DIFF
--- a/Importer.pm
+++ b/Importer.pm
@@ -306,6 +306,8 @@ sub _prepareTrack {
 		CHANNELS     => $track->{maximum_channel_count},
 		LOSSLESS     => $ct eq 'flc',
 		RELEASETYPE  => $album->{release_type} =~ /^[a-z]+$/ ? ucfirst($album->{release_type}) : $album->{release_type},
+		REPLAYGAIN_ALBUM_GAIN => $album->{replay_gain},
+		REPLAYGAIN_ALBUM_PEAK => $album->{replay_peak},
 	};
 
 	if ($album->{media_count} > 1) {
@@ -323,6 +325,7 @@ sub _prepareTrack {
 
 	if ($track->{audio_info}) {
 		$attributes->{REPLAYGAIN_TRACK_GAIN} = $track->{audio_info}->{replaygain_track_gain};
+		$attributes->{REPLAYGAIN_TRACK_PEAK} = $track->{audio_info}->{replaygain_track_peak};
 	}
 
 	return $attributes;


### PR DESCRIPTION
Import album replay gain and peak gain values for possible future use and to make album gain visible in track info.

Use "album_with_tracks" cache when calculating album gain for tracks on favorited albums that have expired from the "albumInfo" cache. Formerly these albums would be played with track gain, which is incorrect behavior. I noticed this happening on albums played from the library that had been originally favorited more than 30 days ago, which is the default expiry for "albumInfo" and "trackInfo" items, whereas the "album_with_tracks" items created by the import process have a 90-day expiry AND are re-created each time a scan is performed, minimizing, if not eliminating, the chances of the problem occurring.