### PR TITLE
Always set 'title' element

### DIFF
--- a/Plugin.pm
+++ b/Plugin.pm
@@ -1703,7 +1703,6 @@ sub _albumItem {
 		album_id => $album->{id},
 		album_title => $album->{title},
 	}];
-$item->{version}= 'darrell album';
 
 	return $item;
 }
@@ -1841,7 +1840,6 @@ sub _trackItem {
 	$item->{tracknum} = $track->{track_number};
 	$item->{media_number} = $track->{media_number};
 	$item->{media_count} = $track->{album}->{media_count};
-$item->{titleFlags}= 'darrell track';
 	return $item;
 }
 


### PR DESCRIPTION
Something's happening in XMLBrowser which messes up the title format when the extra metadata is passed back, so only return it when we've got the `$tags` parameter.

Maybe we should look at XMLBrowser, in case we ever wanted to use `$tags` in Default Skin requests?