### PR TITLE
Disable "MyWeeklyQ", etc.

### DIFF
--- a/Importer.pm
+++ b/Importer.pm
@@ -335,6 +335,7 @@ sub _prepareTrack {
 
 	my $url = Plugins::Qobuz::API::Common->getUrl(undef, $track) || return;
 	my $ct  = Slim::Music::Info::typeFromPath($url);
+	my $bitrate = Slim::Player::Song::guessBitrateFromFormat($ct, undef, $track->{maximum_bit_depth}, $track->{maximum_sampling_rate} * 1000);
 
 	my $attributes = {
 		url          => $url,
@@ -354,6 +355,7 @@ sub _prepareTrack {
 		SAMPLESIZE   => $track->{maximum_bit_depth},
 		CHANNELS     => $track->{maximum_channel_count},
 		LOSSLESS     => $ct eq 'flc',
+		BITRATE      => $bitrate,
 		RELEASETYPE  => $album->{release_type} =~ /^[a-z]+$/ ? ucfirst($album->{release_type}) : $album->{release_type},
 		REPLAYGAIN_ALBUM_GAIN => $album->{replay_gain},
 		REPLAYGAIN_ALBUM_PEAK => $album->{replay_peak},

--- a/Importer.pm
+++ b/Importer.pm
@@ -335,7 +335,7 @@ sub _prepareTrack {
 
 	my $url = Plugins::Qobuz::API::Common->getUrl(undef, $track) || return;
 	my $ct  = Slim::Music::Info::typeFromPath($url);
-	my $bitrate = Slim::Player::Song::guessBitrateFromFormat($ct, undef, $track->{maximum_bit_depth}, $track->{maximum_sampling_rate} * 1000);
+	my $bitrate = ($ct eq 'mp3' ? 320 : $track->{maximum_bit_depth} * $track->{maximum_sampling_rate}) * 1000;
 
 	my $attributes = {
 		url          => $url,

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -365,11 +365,11 @@ sub handleFeed {
 		image => 'html/images/genres.png',
 		type => 'link',
 		url  => \&QobuzGenres
-	},{
-		name => cstring($client, 'PLUGIN_QOBUZ_MYWEEKLYQ'),
-		type  => 'playlist',
-		url  => \&QobuzMyWeeklyQ,
-		image => 'html/images/playlists.png'
+#	},{
+#		name => cstring($client, 'PLUGIN_QOBUZ_MYWEEKLYQ'),
+#		type  => 'playlist',
+#		url  => \&QobuzMyWeeklyQ,
+#		image => 'html/images/playlists.png'
 	}];
 
 	if ($client && scalar @{ Plugins::Qobuz::API::Common::getAccountList() } > 1) {


### PR DESCRIPTION
1. Disable "MyWeeklyQ".
2. Populate the `bitrate` attribute with estimated values based on sample rate and depth for tracks imported into the library.

I wanted these commits to be two separate PR's, but Github had it's own ideas. 

P.S. Take it easy on me in the review. It's my birthday.